### PR TITLE
fix temporary citation collection cleanup

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -95,8 +95,9 @@ async function startup({ id, version, resourceURI, rootURI }, reason) {
     Services.scriptloader.loadSubScript(`${rootURI}/chrome/content/scripts/index.js`, ctx);
 }
 
-function shutdown({ id, version, resourceURI, rootURI }, reason) {
+async function shutdown({ id, version, resourceURI, rootURI }, reason) {
     if (reason === APP_SHUTDOWN) {
+        await Zotero.__addonInstance__?.hooks.onShutdown();
         return;
     }
     if (reason == ADDON_DISABLE) {
@@ -107,7 +108,7 @@ function shutdown({ id, version, resourceURI, rootURI }, reason) {
             Components.interfaces.nsISupports,
         ).wrappedJSObject;
     }
-    Zotero.__addonInstance__.hooks.onShutdown();
+    await Zotero.__addonInstance__.hooks.onShutdown();
 
     Cc["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService).flushBundles();
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "watch": "chokidar \"src/**\" \"addon/**\" -c \"npm run reload\"",
         "release": "release-it",
         "lint": "prettier --write . && eslint . --ext .ts --fix",
-        "test": "echo \"Error: no test specified\" && exit 1",
+        "test": "node scripts/test.mjs",
         "update-deps": "npm update --save"
     },
     "repository": {

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -1,0 +1,13 @@
+import { build } from "esbuild";
+
+const result = await build({
+    entryPoints: ["test/citationUtils.test.ts"],
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    target: "node18",
+    write: false,
+});
+
+const source = result.outputFiles[0].text;
+await import(`data:text/javascript;base64,${Buffer.from(source).toString("base64")}`);

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -1,6 +1,7 @@
-import {ZoteroToolkit} from "zotero-plugin-toolkit";
+import { ZoteroToolkit } from "zotero-plugin-toolkit";
 import hooks from "./hooks";
 import { citeItems } from "./modules/cite";
+import type Citation from "./modules/citation";
 
 class Addon {
     public data: {
@@ -16,7 +17,8 @@ class Addon {
             window: Window;
             rows: Array<{ [dataKey: string]: string }>;
         };
-        docId: "__doc__"
+        citation?: Citation;
+        docId: string;
     };
     // Lifecycle hooks
     public hooks: typeof hooks;
@@ -31,6 +33,7 @@ class Addon {
             env: __env__,
             // ztoolkit: new MyToolkit(),
             ztoolkit: new ZoteroToolkit(),
+            docId: "__doc__",
         };
         this.hooks = hooks;
         this.api = { citeItems: citeItems };

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -4,11 +4,24 @@ import Citation from "./modules/citation";
 import { citeItems } from "./modules/cite";
 import Views from "./modules/views";
 
+const keydownHandler = (event: any) => {
+    if (event.key.toLowerCase() == "'") {
+        ztoolkit.log(event);
+        if (event.originalTarget.isContentEditable || "value" in event.originalTarget) {
+            return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        citeItems();
+    }
+};
+
 async function onStartup() {
     await Promise.all([Zotero.initializationPromise, Zotero.unlockPromise, Zotero.uiReadyPromise]);
     initLocale();
 
     const citation = new Citation();
+    addon.data.citation = citation;
     await citation.listener(1000);
 
     const views = new Views();
@@ -16,29 +29,21 @@ async function onStartup() {
     await views.createCitationColumn();
     await views.dragCite();
 
-    document.addEventListener(
-        "keydown",
-        (event: any) => {
-            if (event.key.toLowerCase() == "'") {
-                ztoolkit.log(event)
-                if (event.originalTarget.isContentEditable || "value" in event.originalTarget) {
-                    return;
-                }
-                event.preventDefault();
-                event.stopPropagation();
-                citeItems();
-            }
-        },
-        true,
-    );
+    document.addEventListener("keydown", keydownHandler, true);
 }
 
-function onShutdown(): void {
-    ztoolkit.unregisterAll();
-    ztoolkit.Prompt.unregisterAll();
-    // Remove addon object
-    addon.data.alive = false;
-    delete Zotero[config.addonInstance];
+async function onShutdown(): Promise<void> {
+    try {
+        document.removeEventListener("keydown", keydownHandler, true);
+        await addon.data.citation?.clear();
+    } finally {
+        addon.data.citation = undefined;
+        ztoolkit.unregisterAll();
+        ztoolkit.Prompt.unregisterAll();
+        // Remove addon object
+        addon.data.alive = false;
+        delete Zotero[config.addonInstance];
+    }
 }
 
 export default {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,5 +19,5 @@ if (!basicTool.getGlobal("Zotero")[config.addonInstance]) {
     ztoolkit.UI.basicOptions.ui.enableElementJSONLog = false;
     Zotero[config.addonInstance] = addon;
     // Trigger addon hook for initialization
-    addon.hooks.onStartup();
+    addon.hooks.onStartup().catch((error) => Zotero.logError(error));
 }

--- a/src/modules/citation.ts
+++ b/src/modules/citation.ts
@@ -1,230 +1,353 @@
-import { config } from "../../package.json";
+import { diffItemIDs, isLegacyCitationSearch } from "./citationUtils";
+
+const TEMP_COLLECTION_RELATION = "dc:relation";
+const TEMP_COLLECTION_MARKER = "https://github.com/MuiseDestiny/zotero-citation#temporary-collection";
+const RENAME_TIMEOUT = 5000;
 
 export default class Citation {
     public sessions: { [sessionID: string]: SessionData } = {};
-    public intervalID!: number;
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    private filterFunctions: Function[] = [];
+
+    private intervalID?: number;
+    private pollPromise?: Promise<void>;
+    private clearPromise?: Promise<void>;
+    private closing = false;
+    private execCommandDepth = 0;
+    private originalExecCommand?: typeof Zotero.Integration.execCommand;
+    private patchedExecCommand?: typeof Zotero.Integration.execCommand;
+    private pendingTasks = new Set<Promise<void>>();
+
     constructor() {
         Zotero.ZoteroCitation.api.sessions = this.sessions;
-        const filterFunctions = this.filterFunctions;
-        try {
-            ztoolkit.patch(
-                Zotero.CollectionTreeRow.prototype,
-                "getItems",
-                config.addonRef,
-                (original) =>
-                    async function () {
-                        // @ts-ignore ignore
-                        let items = await original.call(this);
-                        for (let i = 0; i < filterFunctions.length; i++) {
-                            items = filterFunctions[i](items);
-                        }
-                        return items;
-                    },
-            );
-        } catch {
-            /* empty */
-        }
     }
 
     /**
-     * 删除历史清除失效的文件夹
+     * Remove temporary collections left by an interrupted shutdown and migrate
+     * the all-items saved searches created by older versions of the plugin.
      */
-    public async clearSearch() {
-        let i = 0;
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-            const row = ZoteroPane.collectionsView.getRow(i) as any;
-            if (!row) {
-                break;
-            }
-            if (row?.ref?._ObjectType == "Search") {
-                const conditions = row.ref.getConditions();
-                if (Object.values(conditions).length == 1) {
-                    const condition = conditions[0];
-                    if (condition.condition == "title" && condition.value == "") {
-                        const search = row.ref;
-                        if (
-                            Object.values(this.sessions)
-                                .map((s: SessionData) => s.search?.key)
-                                .indexOf(search.key) == -1
-                        ) {
-                            await search.eraseTx();
-                            console.log("delete", search.name);
-                            i -= 1;
-                        }
-                    }
+    private async clearStaleArtifacts() {
+        const libraryID = Zotero.Libraries.userLibraryID;
+        const collections = (Zotero.Collections as any).getByLibrary(libraryID, true, true) as Zotero.Collection[];
+
+        for (const collection of collections) {
+            try {
+                await collection.loadDataType("relations");
+                if (collection.getRelationsByPredicate(TEMP_COLLECTION_RELATION).includes(TEMP_COLLECTION_MARKER)) {
+                    await collection.eraseTx();
                 }
+            } catch (error) {
+                this.logError("Failed to remove a stale citation collection", error);
             }
-            i += 1;
+        }
+
+        const searches = (Zotero.Searches as any).getByLibrary(libraryID) as Zotero.Search[];
+        for (const search of searches) {
+            try {
+                if (isLegacyCitationSearch(search.getConditions() as any)) {
+                    await search.eraseTx();
+                }
+            } catch (error) {
+                this.logError("Failed to remove a legacy citation search", error);
+            }
         }
     }
 
     /**
-     * 监听session状态以生成搜索目录
+     * Watch Word integration sessions and keep their temporary collections in sync.
      */
     public async listener(t: number) {
-        let isExecCommand = false;
-        this.intervalID = window.setInterval(async () => {
-            if (!Zotero.ZoteroCitation) {
-                return this.clear();
+        await this.clearStaleArtifacts();
+        this.patchExecCommand();
+        window.addEventListener("close", this.handleWindowClose);
+        this.intervalID = window.setInterval(() => this.schedulePoll(), t);
+        this.schedulePoll();
+    }
+
+    private schedulePoll() {
+        if (this.closing || this.pollPromise) {
+            return;
+        }
+
+        const task = this.pollSessions()
+            .catch((error) => this.logError("Failed to refresh citation collections", error))
+            .finally(() => {
+                if (this.pollPromise === task) {
+                    this.pollPromise = undefined;
+                }
+            });
+        this.pollPromise = task;
+    }
+
+    private async pollSessions() {
+        if (this.closing || this.execCommandDepth > 0) {
+            return;
+        }
+
+        const integrationSessions = Zotero.Integration.sessions;
+        const wordSessionIDs = Object.keys(integrationSessions).filter((sessionID) =>
+            String(integrationSessions[sessionID].agent).includes("Word"),
+        );
+        const activeSessionIDs = new Set(wordSessionIDs);
+
+        for (const sessionID of Object.keys(this.sessions)) {
+            if (!activeSessionIDs.has(sessionID)) {
+                await this.clearSession(sessionID);
             }
-            if (!Zotero.Integration.currentSession || isExecCommand) {
+        }
+
+        if (this.closing) {
+            return;
+        }
+
+        for (const sessionID of wordSessionIDs) {
+            if (this.closing || this.execCommandDepth > 0) {
                 return;
             }
-            const sessions = Zotero.Integration.sessions;
-            const _sessions = this.sessions;
-            for (const sessionID in sessions) {
-                const session = sessions[sessionID];
-                let _session: SessionData;
-                if (!(session.agent as string).includes("Word")) {
+
+            const integrationSession = integrationSessions[sessionID];
+            let session = this.sessions[sessionID];
+            if (!session) {
+                session = {
+                    collection: undefined,
+                    idData: {},
+                    lastName: sessionID,
+                    pending: true,
+                };
+                this.sessions[sessionID] = session;
+
+                try {
+                    await this.initCollection(sessionID, session);
+                } catch (error) {
+                    delete this.sessions[sessionID];
+                    this.logError(`Failed to create a citation collection for session ${sessionID}`, error);
                     continue;
+                } finally {
+                    session.pending = false;
                 }
-                // 初始化对象的session
-                if (sessionID in _sessions) {
-                    _session = _sessions[sessionID];
-                } else {
-                    _sessions[sessionID] = _session = { search: undefined, idData: {}, pending: true } as SessionData;
-                    await this.initSearch(sessionID);
-                    _session.pending = false;
-                }
-                // 其它线程search正在创建，则退出本次执行
-                if (_session.pending == true && !_session.search) {
-                    return;
-                }
-                const citationsByItemID = session.citationsByItemID;
-                // 分析排序
-                const sortedItemIDs = this.getSortedItemIDs(session.citationsByIndex);
-                this.updateCitations(sessionID, citationsByItemID, sortedItemIDs, session.styleClass);
             }
-        }, t);
-        window.addEventListener("close", (event) => {
-            event.preventDefault();
+
+            if (!session.collection) {
+                continue;
+            }
+
+            const citationsByItemID = integrationSession.citationsByItemID || {};
+            const sortedItemIDs = this.getSortedItemIDs(integrationSession.citationsByIndex || {});
+            await this.updateCitations(sessionID, citationsByItemID, sortedItemIDs, integrationSession.styleClass);
+        }
+    }
+
+    private async initCollection(sessionID: string, session: SessionData) {
+        const collection = new Zotero.Collection();
+        (collection as any).libraryID = Zotero.Libraries.userLibraryID;
+        collection.name = sessionID;
+        collection.addRelation(TEMP_COLLECTION_RELATION, TEMP_COLLECTION_MARKER);
+        await collection.saveTx({ skipSelect: true });
+
+        if (this.closing || this.sessions[sessionID] !== session) {
+            await collection.eraseTx();
+            return;
+        }
+
+        session.collection = collection;
+    }
+
+    private patchExecCommand() {
+        if (this.patchedExecCommand) {
+            return;
+        }
+
+        this.originalExecCommand = Zotero.Integration.execCommand;
+        this.patchedExecCommand = (async (...args: any[]) => {
+            this.execCommandDepth += 1;
+            let result;
             try {
-                this.clear();
-            } catch {
-                /* empty */
+                result = await (this.originalExecCommand as any).apply(Zotero.Integration, args);
+            } finally {
+                this.execCommandDepth = Math.max(0, this.execCommandDepth - 1);
             }
-            window.setTimeout(() => {
-                window.close();
-            });
-        });
-        const execCommand = Zotero.Integration.execCommand;
-        const _sessions = this.sessions;
-        // @ts-ignore ignore
-        Zotero.Integration.execCommand = (async function (agent, command, docId) {
-            // eslint-disable-next-line prefer-rest-params
-            console.log(...arguments);
-            isExecCommand = true;
-            // eslint-disable-next-line prefer-rest-params
-            await execCommand.bind(Zotero.Integration)(...arguments);
-            isExecCommand = false;
-            // if (docId.endsWith("__doc__")) {
-            //     return;
-            // }
-            const id = window.setInterval(async () => {
-                const sessionID = Zotero.Integration?.currentSession?.sessionID;
-                if (!sessionID) {
-                    console.log("sessionID is null, waiting...");
-                    return;
-                }
-                window.clearInterval(id);
-                console.log("clear interval");
-                let _session;
-                while (!((_session ??= _sessions[sessionID]) && _session.search)) {
-                    await Zotero.Promise.delay(10);
-                }
-                console.log(_sessions);
-                // 判断是否为插件修改过的名称，如果是则更新
-                // 若为用户更改则不进行更新
-                if ([sessionID, _session.lastName].indexOf(_session.search.name) != -1) {
-                    addon.data.docId = docId
-                    let targetName = docId
-                    try {
-                        targetName = PathUtils.split(docId).slice(-1)[0];
-                    } catch { }
- 
-                    console.log(`${_session.search.name}->${targetName}`);
-                    // 修复Mac储存
-                    if (targetName && targetName.trim().length > 0) {
-                        _session.search.name = _session.lastName = targetName;
-                        await _session.search.saveTx({ skipSelect: true });
+
+            const docId = args[2];
+            if (typeof docId === "string" && !this.closing) {
+                this.trackTask(this.renameCurrentCollection(docId));
+            }
+            return result;
+        }) as typeof Zotero.Integration.execCommand;
+        Zotero.Integration.execCommand = this.patchedExecCommand;
+    }
+
+    private restoreExecCommand() {
+        if (
+            this.originalExecCommand &&
+            this.patchedExecCommand &&
+            Zotero.Integration.execCommand === this.patchedExecCommand
+        ) {
+            Zotero.Integration.execCommand = this.originalExecCommand;
+        }
+        this.originalExecCommand = undefined;
+        this.patchedExecCommand = undefined;
+    }
+
+    private trackTask(task: Promise<void>) {
+        this.pendingTasks.add(task);
+        void task
+            .catch((error) => this.logError("Failed to rename a citation collection", error))
+            .finally(() => this.pendingTasks.delete(task));
+    }
+
+    private async renameCurrentCollection(docId: string) {
+        const deadline = Date.now() + RENAME_TIMEOUT;
+        while (!this.closing && Date.now() < deadline) {
+            const sessionID = Zotero.Integration.currentSession?.sessionID;
+            const session = sessionID ? this.sessions[sessionID] : undefined;
+            if (sessionID && session?.collection) {
+                if ([sessionID, session.lastName].includes(session.collection.name)) {
+                    const targetName = this.getDocumentName(docId);
+                    if (targetName) {
+                        addon.data.docId = docId;
+                        session.collection.name = targetName;
+                        await session.collection.saveTx({ skipSelect: true });
+                        session.lastName = targetName;
                     }
                 }
-            }, 0);
-        });
+                return;
+            }
+            await Zotero.Promise.delay(50);
+        }
+    }
+
+    private getDocumentName(docId: string) {
+        let targetName = docId;
+        try {
+            targetName = PathUtils.split(docId).slice(-1)[0];
+        } catch {
+            // Keep the original document identifier when it is not a filesystem path.
+        }
+        return targetName?.trim() || "";
     }
 
     public getSortedItemIDs(citationsByIndex: any) {
-        const SortedItemIDs: number[] = [];
+        const sortedItemIDs: number[] = [];
         for (const i in citationsByIndex) {
             citationsByIndex[i].citationItems.forEach((item: { id: number }) => {
-                if (SortedItemIDs.indexOf(item.id) == -1) {
-                    SortedItemIDs.push(item.id);
+                if (!sortedItemIDs.includes(item.id)) {
+                    sortedItemIDs.push(item.id);
                 }
             });
         }
-        return SortedItemIDs;
+        return sortedItemIDs;
     }
 
-    public updateCitations(sessionID: string, citationsByItemID: { [id: string]: any[] }, sortedItemIDs: number[], styleClass: "in-text" | "note") {
-        // 数据是否有变动
+    public async updateCitations(
+        sessionID: string,
+        citationsByItemID: { [id: string]: any[] },
+        sortedItemIDs: number[],
+        styleClass: "in-text" | "note",
+    ) {
         const getPlainCitation = (id: string) =>
             sortedItemIDs.indexOf(Number(id)) +
             ": " +
-            citationsByItemID[id].map((i) =>
-                // 如果是note类型的style是脚注形式，则直接返回数字
-                styleClass == "note" ?
-                String(sortedItemIDs.indexOf(Number(id)) + 1)
-                :
-                i.properties.plainCitation
-            ).join(", ");
-        // 待更新新数据
-        const targetData: any = {};
+            citationsByItemID[id]
+                .map((citation) =>
+                    styleClass === "note"
+                        ? String(sortedItemIDs.indexOf(Number(id)) + 1)
+                        : citation.properties.plainCitation,
+                )
+                .join(", ");
+        const targetData: { [id: string]: { plainCitation: string } } = {};
         for (const id of Object.keys(citationsByItemID)) {
             targetData[id] = { plainCitation: getPlainCitation(id) };
         }
-        // 与旧数据比较
-        if (JSON.stringify(targetData) == JSON.stringify(this.sessions[sessionID].idData)) {
+
+        const session = this.sessions[sessionID];
+        if (!session || JSON.stringify(targetData) === JSON.stringify(session.idData)) {
             return;
-        } else {
-            this.sessions[sessionID].idData = targetData;
-            ZoteroPane.itemsView.refreshAndMaintainSelection();
+        }
+
+        const targetIDs = Object.keys(targetData)
+            .map(Number)
+            .filter((id) => {
+                const item = Zotero.Items.get(id);
+                return item && item.libraryID === Zotero.Libraries.userLibraryID;
+            });
+        await this.syncCollectionItems(session, targetIDs);
+        session.idData = targetData;
+        (ZoteroPane.itemsView as any).refreshAndMaintainSelection();
+    }
+
+    private async syncCollectionItems(session: SessionData, targetIDs: number[]) {
+        const collection = session.collection;
+        if (!collection) {
+            return;
+        }
+
+        const currentIDs = collection.getChildItems(true) as number[];
+        const changes = diffItemIDs(currentIDs, targetIDs);
+        if (!changes.add.length && !changes.remove.length) {
+            return;
+        }
+
+        await Zotero.DB.executeTransaction(async () => {
+            await collection.removeItems(changes.remove);
+            await collection.addItems(changes.add);
+        });
+    }
+
+    private async clearSession(sessionID: string) {
+        const session = this.sessions[sessionID];
+        if (!session) {
+            return;
+        }
+        delete this.sessions[sessionID];
+
+        if (session.collection?.id) {
+            await session.collection.eraseTx();
         }
     }
 
-    public async initSearch(sessionID: string) {
-        let search = new Zotero.Search();
-        search.addCondition("title", "contains", "");
-        await search.search();
-        search.name = sessionID;
-        const session: SessionData = this.sessions[sessionID];
-        session.search = search = search.clone(1);
-        await search.saveTx({ skipSelect: true });
-        this.filterFunctions.push((items: Zotero.Item[]) => {
-            // 当前处在伪搜索文件夹中才进行拦截
-            const selectedSearch = ZoteroPane.collectionsView.getSelectedSearch();
-            if (selectedSearch.key == search.key) {
-                const ids = Object.keys(session.idData).map((id) => Number(id));
-                return items.filter((item) => ids.indexOf(item.id) != -1);
-            } else {
-                return items;
-            }
-        });
-        window.setTimeout(async () => {
-            await this.clearSearch();
-        }, 233);
-    }
+    private handleWindowClose = (event: Event) => {
+        if (this.closing) {
+            return;
+        }
+        event.preventDefault();
+        void this.clear()
+            .catch((error) => this.logError("Failed to clear citation collections during shutdown", error))
+            .finally(() => window.close());
+    };
 
     /**
-     * 退出时调用
+     * Stop background work, restore patched APIs and wait for all collection
+     * deletions to commit before the plugin or Zotero window is unloaded.
      */
-    public clear() {
-        window.clearInterval(this.intervalID);
-        Object.values(this.sessions).forEach(async (session: SessionData) => {
-            // @ts-ignore ignore
-            await session.search.eraseTx();
-        });
+    public clear(): Promise<void> {
+        if (!this.clearPromise) {
+            this.clearPromise = this.performClear();
+        }
+        return this.clearPromise;
+    }
+
+    private async performClear() {
+        this.closing = true;
+        if (this.intervalID !== undefined) {
+            window.clearInterval(this.intervalID);
+            this.intervalID = undefined;
+        }
+        window.removeEventListener("close", this.handleWindowClose);
+        this.restoreExecCommand();
+
+        const activeTasks = [this.pollPromise, ...this.pendingTasks].filter(Boolean) as Promise<void>[];
+        await Promise.allSettled(activeTasks);
+
+        const results = await Promise.allSettled(
+            Object.keys(this.sessions).map((sessionID) => this.clearSession(sessionID)),
+        );
+        for (const result of results) {
+            if (result.status === "rejected") {
+                this.logError("Failed to remove a citation collection", result.reason);
+            }
+        }
+    }
+
+    private logError(context: string, error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        Zotero.logError(new Error(`${context}: ${message}`));
     }
 }

--- a/src/modules/citationUtils.ts
+++ b/src/modules/citationUtils.ts
@@ -1,0 +1,25 @@
+export interface SearchConditionLike {
+    condition: string;
+    operator: string;
+    value: string;
+}
+
+export function isLegacyCitationSearch(conditions: Record<string, SearchConditionLike>): boolean {
+    const values = Object.values(conditions);
+    if (values.length !== 1) {
+        return false;
+    }
+
+    const condition = values[0];
+    return condition.condition === "title" && condition.operator === "contains" && condition.value === "";
+}
+
+export function diffItemIDs(current: number[], target: number[]) {
+    const currentIDs = new Set(current);
+    const targetIDs = new Set(target);
+
+    return {
+        add: [...targetIDs].filter((id) => !currentIDs.has(id)),
+        remove: [...currentIDs].filter((id) => !targetIDs.has(id)),
+    };
+}

--- a/src/modules/views.ts
+++ b/src/modules/views.ts
@@ -17,22 +17,17 @@ class Views {
       ) => {
         try {
           const currentSession = Zotero.Integration.currentSession;
-          if (!currentSession) {
-            return "";
-          }
-          const search =
-            ZoteroPane.collectionsView.getSelectedSearch() ||
-            Zotero.ZoteroCitation.api.sessions[currentSession.sessionID].search;
-          if (!search) {
-            return "";
-          }
-          const session = Object.values(Zotero.ZoteroCitation.api.sessions).find(
-            (session: any) => session.search.key == search.key,
-          ) as SessionData;
-          if (session) {
-            return session.idData[item.id].plainCitation;
-          }
-          return ""
+          const selectedCollection = (ZoteroPane.collectionsView as any).getSelectedCollection();
+          const selectedSession = selectedCollection
+            ? Object.values(Zotero.ZoteroCitation.api.sessions).find(
+                (candidate: any) => candidate.collection?.key == selectedCollection.key,
+              )
+            : undefined;
+          const session = (selectedSession ||
+            (currentSession
+              ? Zotero.ZoteroCitation.api.sessions[currentSession.sessionID]
+              : undefined)) as SessionData | undefined;
+          return session?.idData[item.id]?.plainCitation || "";
         } catch {
           return "";
         }
@@ -92,7 +87,7 @@ class Views {
   }
 
   public async dragCite() {
-    ztoolkit.patch(
+    (ztoolkit.patch as any)(
       ZoteroPane.itemsView,
       "onDragStart",
       config.addonRef,
@@ -108,21 +103,21 @@ class Views {
 
   public async patchIcon() {
     try {
-      ztoolkit.patch(
+      (ztoolkit.patch as any)(
         ZoteroPane.collectionsView,
         "renderItem",
         config.addonRef,
-        (original) => (index: number, selection: object, oldDiv: HTMLDivElement, columns: any[]) => {
-          const div = original.call(ZoteroPane.collectionsView, index, selection, oldDiv, columns) as HTMLDivElement;
-          const row = ZoteroPane.collectionsView!.getRow(index) as any;
+        (original: any) => (index: number, selection: object, oldDiv: HTMLDivElement, columns: any[]) => {
+          const div = (original as any).call(ZoteroPane.collectionsView, index, selection, oldDiv, columns) as HTMLDivElement;
+          const row = (ZoteroPane.collectionsView as any).getRow(index) as any;
           if (
             Object.values(Zotero.ZoteroCitation.api.sessions)
-              .map((s: any) => s.search?.key)
+              .map((s: any) => s.collection?.key)
               .indexOf(row?.ref?.key) != -1
           ) {
             const iconNode = div.querySelector(".cell-icon") as HTMLDivElement;
             iconNode.style.backgroundImage = `url(chrome://${config.addonRef}/content/icons/word.png)`;
-            iconNode.classList.remove("icon-search")
+            iconNode.classList.remove("icon-collection", "icon-search")
             iconNode.classList.add("icon-publications")
           }
           return div;
@@ -135,7 +130,7 @@ class Views {
 
   private getColumnInfo(dataKey: string) {
     try {
-      // @ts-ignore
+      // @ts-ignore Zotero's internal column registry is not exposed in zotero-types.
       const columnInfo = ZoteroPane.itemsView._columns.find((i: any) => i.dataKey.endsWith(dataKey))
       return columnInfo
     } catch { return {} }
@@ -143,5 +138,3 @@ class Views {
 }
 
 export default Views;
-
-

--- a/test/citationUtils.test.ts
+++ b/test/citationUtils.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { diffItemIDs, isLegacyCitationSearch } from "../src/modules/citationUtils";
+
+test("detects only the all-items search produced by legacy releases", () => {
+    assert.equal(
+        isLegacyCitationSearch({
+            0: { condition: "title", operator: "contains", value: "" },
+        }),
+        true,
+    );
+    assert.equal(
+        isLegacyCitationSearch({
+            0: { condition: "title", operator: "isEmpty", value: "" },
+        }),
+        false,
+    );
+    assert.equal(
+        isLegacyCitationSearch({
+            0: { condition: "title", operator: "contains", value: "" },
+            1: { condition: "itemType", operator: "is", value: "book" },
+        }),
+        false,
+    );
+});
+
+test("computes collection membership changes without duplicates", () => {
+    assert.deepEqual(diffItemIDs([1, 2, 3], [2, 3, 4, 4]), {
+        add: [4],
+        remove: [1],
+    });
+});

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -27,7 +27,7 @@ interface CitationData {
 
 interface SessionData {
     lastName: string;
-    search: undefined | Zotero.Search;
+    collection: undefined | Zotero.Collection;
     idData: { [id: string]: any };
     pending: boolean;
 }

--- a/update.json
+++ b/update.json
@@ -3,7 +3,7 @@
         "zoterocitation@polygon.org": {
             "updates": [
                 {
-                    "version": "0.5.3",
+                    "version": "0.5.4",
                     "update_link": "https://github.com/muisedestiny/eaiser-citation/releases/latest/download/zotero-citation.xpi",
                     "applications": {
                         "gecko": {
@@ -12,7 +12,7 @@
                     }
                 },
                 {
-                    "version": "0.5.3",
+                    "version": "0.5.4",
                     "update_link": "https://github.com/muisedestiny/eaiser-citation/releases/latest/download/zotero-citation.xpi",
                     "applications": {
                         "zotero": {


### PR DESCRIPTION
## Summary

This PR fixes temporary Word citation folders that sometimes survive Zotero shutdown and reopen showing the entire library.

Instead of persisting an all-items saved search whose results are filtered only in memory, the plugin now creates a marked temporary collection containing only the items cited by the corresponding Word session.

## Root cause

The previous implementation saved a search with the condition `title contains ""`. Zotero evaluates this as nearly the entire library, while the plugin monkey-patched `CollectionTreeRow.getItems()` to filter the result in memory.

Cleanup was not properly awaited: `clear()` was non-async and used `forEach(async ...)`, so shutdown could finish before `eraseTx()` committed. If the search survived shutdown, the in-memory filter was lost after restart and the saved search displayed the whole library.

Legacy cleanup was also triggered only after another Word session created a new search, matching the behavior described in #186.

## What changed

* Replace the all-items saved search with a temporary Zotero collection containing the actual cited items.
* Synchronize collection membership when citations are added or removed.
* Delete the collection when its Word integration session disappears.
* Mark generated collections with a durable relation so leftovers from interrupted shutdowns can be identified safely.
* Remove stale marked collections during startup.
* Migrate legacy searches only when their single condition is exactly `title contains ""`; searches such as `title is empty` are not affected.
* Await cleanup during window close, add-on shutdown, and `APP_SHUTDOWN`.
* Restore the original `Zotero.Integration.execCommand` and remove timers/listeners during shutdown.
* Reset integration-command state in `finally` and replace unbounded zero-delay polling with a bounded wait.
* Add tests for legacy-search detection and collection membership updates.
* Regenerate `update.json` to match package version `0.5.4`.

## User impact

If cleanup is interrupted, a marked collection may temporarily remain until the next startup, but it can no longer expose the entire Zotero library because it contains only the cited items.

This addresses the temporary-folder lifecycle symptoms reported in #140, #150, #163, #186, and #187.

## Validation

* `npm test`
* `npm run tsc`
* `npx eslint src typings test --ext .ts`
* `npm run build`
